### PR TITLE
Update to voxel-engine 0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:kumavis/voxel-server.git"
   },
   "dependencies": {
-    "voxel-engine": "0.19.0",
+    "voxel-engine": "0.20.0",
     "voxel-crunch": "0.1.1",
     "minecraft-skin": "0.1.2",
     "voxel-player": "0.1.0",


### PR DESCRIPTION
Just a version update from voxel-engine 0.19.0 to 0.20.0. No code changes required since this version is backwards-compatible I believe (had to change this version since my peer dependencies wouldn't be satisfied..)

The other dependencies could be updated too (voxel-crunch from 0.1.1 to 0.2.1, duplex-emitter 0.1.10 to 2.1.2, extend 1.1.3 to 1.2.1) but those are larger version jumps, haven't tested their compatibility, but at least voxel-engine 0.19.0 to 0.20.0 should be compatible.
