### PR TITLE
Update voxel-crunch and duplex-emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "voxel-engine": "0.20.0",
-    "voxel-crunch": "0.1.1",
+    "voxel-crunch": "0.2.1",
     "minecraft-skin": "0.1.2",
     "voxel-player": "0.1.0",
-    "duplex-emitter": "0.1.10",
+    "duplex-emitter": "2.1.2",
     "extend": "1.1.3"
   },
   "engines": {


### PR DESCRIPTION
corresponds to https://github.com/kumavis/voxel-server/pull/1
