### PR TITLE
Send 'set' events on setBlock()

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,9 @@ Client.prototype.bindEvents = function(connection) {
 
   // fires when server sends us voxel edits
   connection.on('set', function(pos, val) {
+    self.serverSettingBlock = true;
     self.game.setBlock(pos, val)
+    self.serverSettingBlock = false;
   })
 
 }
@@ -124,7 +126,14 @@ Client.prototype.createGame = function(settings) {
     })
     if (interacting) sendState()
   })
-    
+
+  // send voxel edits
+  self.game.on('setBlock', function(pos, val) {
+    if (self.serverSettingBlock) return;
+
+    connection.emit('set', pos, val);
+  });
+
   // handle server updates
   // delay is because three.js seems to throw errors if you add stuff too soon
   setTimeout(function() {


### PR DESCRIPTION
voxel-server and voxel-client listen for 'set' events (voxel edits), but I couldn't see anywhere they were sent. This PR sends these 'set' events over the connection on the voxel-engine 'setBlock' event, except when the event is already being processed from a remote voxel edit (to prevent infinite recursion). 

This fixes client/server voxel edits at least in my testing (ref https://github.com/deathcap/voxel-fuel/issues/11, not sure how you handle this in node-warrior?)
