### PR TITLE
Fix for voxel-crunch function invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Client.prototype.bindEvents = function(connection) {
       var lastIndex = Math.max.apply(null,Object.keys(encoded).map(Number))
       encoded.length = lastIndex+1
     }
-    var voxels = crunch.decode(encoded, chunk.length)
+    var voxels = crunch.decode(encoded, chunk)
     chunk.voxels = voxels
     self.game.showChunk(chunk)
   })


### PR DESCRIPTION
voxel-crunch decode expects chunk object rather than length as second parameter.

Changing the signature fixes the client for me (otherwise it renders zero blocks as chunk.voxels gets set to an integer)